### PR TITLE
Add http_upstream_header_time_seconds metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,6 +195,15 @@ LINES:
 			}
 		}
 
+		if headerTime, err := entry.Field("upstream_header_time"); err == nil {
+			if totalTime, err := parseUpstreamTime(headerTime); err == nil {
+				logger.Debug("(%s): matched upstream_header_time to %.3f", file, totalTime)
+				metrics.upstreamHeaderSeconds.WithLabelValues(labelValues...).Observe(totalTime)
+			} else {
+				logger.Warn("(%s): failed to parse upstream_header_time field", file, err)
+			}
+		}
+
 		if responseTime, err := entry.FloatField("request_time"); err == nil {
 			logger.Debug("(%s): matched request_time to %.3f", file, responseTime)
 			metrics.requestSeconds.WithLabelValues(labelValues...).Observe(responseTime)

--- a/metrics.go
+++ b/metrics.go
@@ -6,9 +6,10 @@ import (
 
 // metrics is the struct that contains pointers to our metric containers.
 type metrics struct {
-	bodyBytes       *prometheus.HistogramVec
-	upstreamSeconds *prometheus.HistogramVec
-	requestSeconds  *prometheus.HistogramVec
+	bodyBytes             *prometheus.HistogramVec
+	upstreamHeaderSeconds *prometheus.HistogramVec
+	upstreamSeconds       *prometheus.HistogramVec
+	requestSeconds        *prometheus.HistogramVec
 }
 
 // newMetrics creates a new metrics based on the provided application and
@@ -35,11 +36,19 @@ func newMetrics(application string, labelNames []string) *metrics {
 		ConstLabels: prometheus.Labels{"application": application},
 	}, labelNames)
 
-	prometheus.MustRegister(bodyBytes, upstreamSeconds, requestSeconds)
+	upstreamHeaderSeconds := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:   "nginx",
+		Name:        "http_upstream_header_time_seconds",
+		Help:        "Time to receiving the first byte of the response header from upstream servers",
+		ConstLabels: prometheus.Labels{"application": application},
+	}, labelNames)
+
+	prometheus.MustRegister(bodyBytes, upstreamHeaderSeconds, upstreamSeconds, requestSeconds)
 
 	return &metrics{
-		bodyBytes:       bodyBytes,
-		requestSeconds:  requestSeconds,
-		upstreamSeconds: upstreamSeconds,
+		bodyBytes:             bodyBytes,
+		requestSeconds:        requestSeconds,
+		upstreamSeconds:       upstreamSeconds,
+		upstreamHeaderSeconds: upstreamHeaderSeconds,
 	}
 }


### PR DESCRIPTION
We want to track the time taken for the first byte from the upstream server. Hence adding upstream_header_time metrics.