### PR TITLE
Make histogram buckets configurable

### DIFF
--- a/conf/nginx-log-exporter.yaml.example
+++ b/conf/nginx-log-exporter.yaml.example
@@ -21,6 +21,7 @@ applications:
     replace:
     - path: "^/api/v4/users/[0-9]+/"
       with: "/api/v4/users/<id>/"
+    histogram_buckets: [.05, .1, .2, .5, 1, 2, 5, 10, 20, 30]
   gitlab-pages:
     log_files:
     - "/var/log/gitlab/nginx/gitlab_pages_access.log"

--- a/config.go
+++ b/config.go
@@ -80,10 +80,11 @@ type httpConfig struct {
 
 // appConfig represents a single nginx "application" to export log files for.
 type appConfig struct {
-	Format        string
-	FromBeginning bool `from_beginning`
-	Labels        map[string]string
-	LogFiles      []string `log_files`
+	Format           string
+	FromBeginning    bool `from_beginning`
+	Labels           map[string]string
+	LogFiles         []string  `log_files`
+	HistogramBuckets []float64 `histogram_buckets`
 
 	Exclude []filterConfig
 	Include []filterConfig

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func do_main() error {
 // that belong to a single application
 func monitorApp(name string, ac *appConfig) {
 	ln := append(staticLabels, ac.orderedLabelNames...)
-	metrics := newMetrics(name, ln)
+	metrics := newMetrics(name, ln, ac.HistogramBuckets)
 
 	parser := gonx.NewParser(ac.Format)
 	for _, file := range ac.LogFiles {

--- a/metrics.go
+++ b/metrics.go
@@ -14,11 +14,12 @@ type metrics struct {
 
 // newMetrics creates a new metrics based on the provided application and
 // label names.
-func newMetrics(application string, labelNames []string) *metrics {
+func newMetrics(application string, labelNames []string, histogramBuckets []float64) *metrics {
 	bodyBytes := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   "nginx",
 		Name:        "http_body_bytes_sent",
 		Help:        "Number of body bytes sent to the client",
+		Buckets:     histogramBuckets,
 		ConstLabels: prometheus.Labels{"application": application},
 	}, labelNames)
 
@@ -26,6 +27,7 @@ func newMetrics(application string, labelNames []string) *metrics {
 		Namespace:   "nginx",
 		Name:        "http_request_time_seconds",
 		Help:        "Time spent on processing HTTP requests",
+		Buckets:     histogramBuckets,
 		ConstLabels: prometheus.Labels{"application": application},
 	}, labelNames)
 
@@ -33,6 +35,7 @@ func newMetrics(application string, labelNames []string) *metrics {
 		Namespace:   "nginx",
 		Name:        "http_upstream_response_time_seconds",
 		Help:        "Time spent on receiving a response from upstream servers",
+		Buckets:     histogramBuckets,
 		ConstLabels: prometheus.Labels{"application": application},
 	}, labelNames)
 
@@ -40,6 +43,7 @@ func newMetrics(application string, labelNames []string) *metrics {
 		Namespace:   "nginx",
 		Name:        "http_upstream_header_time_seconds",
 		Help:        "Time to receiving the first byte of the response header from upstream servers",
+		Buckets:     histogramBuckets,
 		ConstLabels: prometheus.Labels{"application": application},
 	}, labelNames)
 


### PR DESCRIPTION
It's needed if we want to measure response times that are slower than 10s