### PR TITLE
feat(replace): add template support in replace config

### DIFF
--- a/conf/nginx-log-exporter.yaml.example
+++ b/conf/nginx-log-exporter.yaml.example
@@ -19,8 +19,12 @@ applications:
       methods:
       - POST
     replace:
+    # when multi regex paths can be matched, only use the first path by the list order
     - path: "^/api/v4/users/[0-9]+/"
       with: "/api/v4/users/<id>/"
+    # use subgroup match with non greedy to capture job value, and render with template
+    - path: "/api/v4/jobs/(?P<job>.*?)/.*"
+      with: "/api/v4/jobs/<{{ .job }}>"
     histogram_buckets: [.05, .1, .2, .5, 1, 2, 5, 10, 20, 30]
   gitlab-pages:
     log_files:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/satyrius/gonx v1.3.0
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -60,10 +60,10 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5 h1:mzjBh+S5frKOsOBobWIMAbXavqjmgO17k/2puhcFR94=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ LINES:
 				logger.Debug("(%s): matched upstream_response_time to %.3f", file, totalTime)
 				metrics.upstreamSeconds.WithLabelValues(labelValues...).Observe(totalTime)
 			} else {
-				logger.Warn("(%s): failed to parse upstream_response_time field", file, err)
+				logger.Warn("(%s): failed to parse upstream_response_time field, line: %s", file, line, err)
 			}
 		}
 
@@ -211,7 +211,7 @@ LINES:
 				logger.Debug("(%s): matched upstream_header_time to %.3f", file, totalTime)
 				metrics.upstreamHeaderSeconds.WithLabelValues(labelValues...).Observe(totalTime)
 			} else {
-				logger.Warn("(%s): failed to parse upstream_header_time field", file, err)
+				logger.Warn("(%s): failed to parse upstream_header_time field, line: %s", file, line, err)
 			}
 		}
 


### PR DESCRIPTION
**Why**

currently if we want to group path in nginx access log, have to hardcode the path node name like below, and if we do not know the path node name, we can not make it grouped:

```
 replace   => [
      { 'path' => '/artifactory/android/.*',                   'with' => '/artifactory/<android>' },
      { 'path' => '/artifactory/api/conda/.*',                 'with' => '/artifactory/api/<conda>' },
      { 'path' => '/artifactory/api/npm/.*',                   'with' => '/artifactory/api/<npm>' },
      { 'path' => '/artifactory/api/maven.*',                  'with' => '/artifactory/api/<maven>' },
      { 'path' => '/artifactory/api/pypi/.*',                  'with' => '/artifactory/api/<pypi>' },
      { 'path' => '/artifactory/bazel-build-test/.*',          'with' => '/artifactory/<bazel>' },
      { 'path' => '/artifactory/gradle-cache-customer-app/.*', 'with' => '/artifactory/<gradle>' },
      { 'path' => '/artifactory/pakket/.*',                    'with' => '/artifactory/<pakket>' },
    ],
```

and with template parsing implemented, we can do it dynamically without knowing the path node name beforehead:

```
replace:      
      - path: "/artifactory/(?P<repo>.*?)/.*"
        with: "/artifactory/<{{ .repo }}>"
```

**Test**

* Ran local with test data

```
    format: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" $request_time "$upstream_response_time" "$upstream_header_time"
    replace:      
      - path: "/artifactory/(?P<repo>.*?)/.*"
        with: "/artifactory/<{{ .repo }}>"
```

```
DEBUG: (access.log): parsing line: '10.218.11.48 - - [02/Jan/2023:18:03:24 +0100] "GET /artifactory/bazel-build-test/remote-cache/bplatform/infra/ac/7d19a134cea97fc09ea141d8026dfef5d92487c3eccd651b0435a03ce55498aa HTTP/1.1" 200 1351 "-" "bazel/5.3.2" "-" 0.036 "0.035" "0.035"'
DEBUG: (access.log): method and path are: GET and /artifactory/bazel-build-test/remote-cache/bplatform/infra/ac/7d19a134cea97fc09ea141d8026dfef5d92487c3eccd651b0435a03ce55498aa
DEBUG: (access.log): found matching replace rule, /artifactory/(?P<repo>.*?)/.* [] -> /artifactory/<{{ .repo }}>
DEBUG: path subgroup matches: [/artifactory/bazel-build-test/remote-cache/bplatform/infra/ac/7d19a134cea97fc09ea141d8026dfef5d92487c3eccd651b0435a03ce55498aa bazel-build-test]
DEBUG: template params: map[repo:bazel-build-test]
DEBUG: (access.log): matched path to /artifactory/<bazel-build-test>
DEBUG: (access.log): matched status to 200
DEBUG: (access.log): matched body_bytes_sent to 1351
DEBUG: (access.log): matched upstream_response_time to 0.035
...
```